### PR TITLE
Listen on IPv6 in Docker container

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -28,6 +28,6 @@ pm2 start /app/api/auth.js
 
 echo "starting http-server for ui"
 #http-server -p 80 -a 0.0.0.0 /app/ui
-pm2 start http-server --name ui -- -p 80 -a 0.0.0.0 -d false /app/ui
+pm2 start http-server --name ui -- -p 80 -a :: -d false /app/ui
 
 pm2 logs


### PR DESCRIPTION
We needed IPv6 addresses visible inside the container, so we could make authorization decisions (issuing JWT to trusted clients).

This change should get the webserver listening on both protocols.